### PR TITLE
Random shuffle before dropping the last few samples

### DIFF
--- a/llava/train/llava_trainer.py
+++ b/llava/train/llava_trainer.py
@@ -205,6 +205,8 @@ class VILADistributedSampler(DistributedSampler):
     def __iter__(self):
 
         indices = list(range(len(self.dataset)))
+        random.seed(self.seed + self.epoch)
+        random.shuffle(indices) # if we don't shuffle here, the final ( len(self.dataset) - self.total_size ) samples will be dropped forever
 
         # 1. split the full indices first (note: without drop last at this moment)
         indices_list = []


### PR DESCRIPTION
I noticed a bug in the data sampler. In the original implementation, the same elements will be dropped in every epoch.

For example, assume the dataset size is 900, and the batch size is 200, then the same 100 samples are dropped every time, which means they are never used in training 