### PR TITLE
Fix torch stack error when there are multiple images with different s…

### DIFF
--- a/llava/model/llava_arch.py
+++ b/llava/model/llava_arch.py
@@ -375,7 +375,8 @@ class LlavaMetaModel(ABC):
                 for x, block_size in zip(image_features, new_block_sizes)
             ]  # list of 1 * C * H * W tensors
             image_features = [rearrange(x, "1 c h w -> (h w) c") for x in image_features]  # list of N * C tensors
-            image_features = torch.stack(image_features, dim=0)
+            if all([feature.shape[0] == image_features[0].shape[0] for feature in image_features]):
+                image_features = torch.stack(image_features, dim=0)
         else:
             image_features = self.get_vision_tower()(images)
             image_features = self.get_mm_projector()(image_features)


### PR DESCRIPTION
…izes in the input

Previously, in `LlavaMetaModel.encode_images`, it will stack the features from different images in the input into a single tensor. However, when the sizes of image are different, it should stack but instead just return the list of the features. This is fine because in `BasicImageEncoder.forward` it will break down the features into a list anyway.