### PR TITLE
fix typo in llava/eva/registry.yaml

### DIFF
--- a/llava/eval/registry.yaml
+++ b/llava/eval/registry.yaml
@@ -125,7 +125,7 @@ lmms-mme:
         - regression
     metrics:
         cognition: results/mme/mme_cognition_score,none
-        perception: results/mme/mme_percetion_score,none
+        perception: results/mme/mme_perception_score,none
 
 lmms-mmmu_pro:
     tags:
@@ -273,49 +273,49 @@ lmms-videomme-8:
         - video
         - regression
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-8:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-videomme-16:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-16:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-videomme-32:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-32:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-videomme-64:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-64:
     tags:
@@ -323,14 +323,14 @@ lmms-videomme_w_subtitle-64:
         - video
         - regression
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-videomme-128:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-128:
     tags:
@@ -338,14 +338,14 @@ lmms-videomme_w_subtitle-128:
         - video
         - regression
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-videomme-256:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-256:
     tags:
@@ -353,14 +353,14 @@ lmms-videomme_w_subtitle-256:
         - video
         - regression
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-videomme-512:
     tags:
         - local
         - video
     metrics:
-        accuracy: results/videomme/videomme_percetion_score,none
+        accuracy: results/videomme/videomme_perception_score,none
 
 lmms-videomme_w_subtitle-512:
     tags:
@@ -368,7 +368,7 @@ lmms-videomme_w_subtitle-512:
         - video
         - regression
     metrics:
-        accuracy: results/videomme_w_subtitle/videomme_percetion_score,none
+        accuracy: results/videomme_w_subtitle/videomme_perception_score,none
 
 lmms-vizwiz_vqa_test:
     tags:


### PR DESCRIPTION
Encountered KeyError: 'videomme_percetion_score,none' in VILA/llava/cli/eval.py

The error occurs at line 181 in eval.py:
```python
val = val[key]
```

Root cause:
There is a spelling mismatch between the key defined in TASKS ('videomme_percetion_score,none') and the key in the results = _load_results() ('videomme_perception_score,none').

Fix:
Correct the spelling of 'percetion' to 'perception' in registry.yaml to maintain consistency.